### PR TITLE
Add QF naval guns

### DIFF
--- a/equipments/SMHG/SMHG009.json
+++ b/equipments/SMHG/SMHG009.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "大口径砲",
+  "common": {
+    "名前": "14-inch/45-caliber gun",
+    "ID": "SMHG009",
+    "重量": 0,
+    "人員": 0,
+    "開発年": 1910,
+    "開発国": "USA",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 0.0,
+    "initial_velocity_mps": 0.0,
+    "rounds_per_minute": 0,
+    "caliber_cm": 35.6,
+    "barrel_length": 45,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMHG/SMHG010.json
+++ b/equipments/SMHG/SMHG010.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "大口径砲",
+  "common": {
+    "名前": "68-pounder gun",
+    "ID": "SMHG010",
+    "重量": 0,
+    "人員": 0,
+    "開発年": 1846,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 0.0,
+    "initial_velocity_mps": 0.0,
+    "rounds_per_minute": 0,
+    "caliber_cm": 20.0,
+    "barrel_length": 0,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMHG/SMHG011.json
+++ b/equipments/SMHG/SMHG011.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "大口径砲",
+  "common": {
+    "名前": "68-pounder Lancaster gun",
+    "ID": "SMHG011",
+    "重量": 0,
+    "人員": 0,
+    "開発年": 1852,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 0.0,
+    "initial_velocity_mps": 0.0,
+    "rounds_per_minute": 0,
+    "caliber_cm": 20.0,
+    "barrel_length": 0,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMHG/SMHG012.json
+++ b/equipments/SMHG/SMHG012.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "大口径砲",
+  "common": {
+    "名前": "BL 9.2-inch Mk I – VII naval gun",
+    "ID": "SMHG012",
+    "重量": 25000,
+    "人員": 12,
+    "開発年": 1880,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 172.0,
+    "initial_velocity_mps": 770.0,
+    "rounds_per_minute": 3,
+    "caliber_cm": 23.4,
+    "barrel_length": 40,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMHG/SMHG013.json
+++ b/equipments/SMHG/SMHG013.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "大口径砲",
+  "common": {
+    "名前": "BL 9.2-inch Mk VIII naval gun",
+    "ID": "SMHG013",
+    "重量": 26000,
+    "人員": 12,
+    "開発年": 1899,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 172.0,
+    "initial_velocity_mps": 762.0,
+    "rounds_per_minute": 3,
+    "caliber_cm": 23.4,
+    "barrel_length": 45,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMHG/SMHG014.json
+++ b/equipments/SMHG/SMHG014.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "大口径砲",
+  "common": {
+    "名前": "BL 9.2-inch Mk IX – X naval gun",
+    "ID": "SMHG014",
+    "重量": 27000,
+    "人員": 12,
+    "開発年": 1900,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 172.0,
+    "initial_velocity_mps": 815.0,
+    "rounds_per_minute": 3,
+    "caliber_cm": 23.4,
+    "barrel_length": 47,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMHG/SMHG015.json
+++ b/equipments/SMHG/SMHG015.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "大口径砲",
+  "common": {
+    "名前": "BL 9.2-inch Mk XI naval gun",
+    "ID": "SMHG015",
+    "重量": 28000,
+    "人員": 12,
+    "開発年": 1901,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 172.4,
+    "initial_velocity_mps": 881.0,
+    "rounds_per_minute": 3,
+    "caliber_cm": 23.4,
+    "barrel_length": 50,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMHG/SMHG016.json
+++ b/equipments/SMHG/SMHG016.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "大口径砲",
+  "common": {
+    "名前": "BL 10-inch Mk I – IV naval gun",
+    "ID": "SMHG016",
+    "重量": 29000,
+    "人員": 14,
+    "開発年": 1880,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 225.0,
+    "initial_velocity_mps": 700.0,
+    "rounds_per_minute": 2,
+    "caliber_cm": 25.4,
+    "barrel_length": 40,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMHG/SMHG017.json
+++ b/equipments/SMHG/SMHG017.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "大口径砲",
+  "common": {
+    "名前": "BL 10-inch Mk VII naval gun",
+    "ID": "SMHG017",
+    "重量": 32000,
+    "人員": 14,
+    "開発年": 1898,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 225.0,
+    "initial_velocity_mps": 815.0,
+    "rounds_per_minute": 2,
+    "caliber_cm": 25.4,
+    "barrel_length": 45,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMHG/SMHG018.json
+++ b/equipments/SMHG/SMHG018.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "大口径砲",
+  "common": {
+    "名前": "BL 12-inch Mk I – II naval gun",
+    "ID": "SMHG018",
+    "重量": 45000,
+    "人員": 16,
+    "開発年": 1886,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 386.0,
+    "initial_velocity_mps": 695.0,
+    "rounds_per_minute": 2,
+    "caliber_cm": 30.5,
+    "barrel_length": 40,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMHG/SMHG019.json
+++ b/equipments/SMHG/SMHG019.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "大口径砲",
+  "common": {
+    "名前": "BL 12-inch Mk III – VII naval gun",
+    "ID": "SMHG019",
+    "重量": 50000,
+    "人員": 16,
+    "開発年": 1895,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 386.0,
+    "initial_velocity_mps": 760.0,
+    "rounds_per_minute": 2,
+    "caliber_cm": 30.5,
+    "barrel_length": 45,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMHG/SMHG020.json
+++ b/equipments/SMHG/SMHG020.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "大口径砲",
+  "common": {
+    "名前": "BL 12-inch Mk IX naval gun",
+    "ID": "SMHG020",
+    "重量": 52000,
+    "人員": 16,
+    "開発年": 1910,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 386.0,
+    "initial_velocity_mps": 859.0,
+    "rounds_per_minute": 2,
+    "caliber_cm": 30.5,
+    "barrel_length": 50,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMHG/SMHG021.json
+++ b/equipments/SMHG/SMHG021.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "大口径砲",
+  "common": {
+    "名前": "BL 12-inch Mk VIII naval gun",
+    "ID": "SMHG021",
+    "重量": 48000,
+    "人員": 16,
+    "開発年": 1901,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 386.0,
+    "initial_velocity_mps": 770.0,
+    "rounds_per_minute": 2,
+    "caliber_cm": 30.5,
+    "barrel_length": 40,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMHG/SMHG022.json
+++ b/equipments/SMHG/SMHG022.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "大口径砲",
+  "common": {
+    "名前": "BL 12-inch Mk X naval gun",
+    "ID": "SMHG022",
+    "重量": 57000,
+    "人員": 16,
+    "開発年": 1906,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 386.0,
+    "initial_velocity_mps": 820.0,
+    "rounds_per_minute": 2,
+    "caliber_cm": 30.5,
+    "barrel_length": 45,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMHG/SMHG023.json
+++ b/equipments/SMHG/SMHG023.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "大口径砲",
+  "common": {
+    "名前": "BL 12-inch Mk XI – XII naval gun",
+    "ID": "SMHG023",
+    "重量": 63000,
+    "人員": 16,
+    "開発年": 1908,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 386.0,
+    "initial_velocity_mps": 860.0,
+    "rounds_per_minute": 2,
+    "caliber_cm": 30.5,
+    "barrel_length": 50,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMHG/SMHG024.json
+++ b/equipments/SMHG/SMHG024.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "大口径砲",
+  "common": {
+    "名前": "BL 13.5-inch Mk I – IV naval gun",
+    "ID": "SMHG024",
+    "重量": 67000,
+    "人員": 18,
+    "開発年": 1888,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 567.0,
+    "initial_velocity_mps": 620.0,
+    "rounds_per_minute": 1,
+    "caliber_cm": 34.3,
+    "barrel_length": 30,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMHG/SMHG025.json
+++ b/equipments/SMHG/SMHG025.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "大口径砲",
+  "common": {
+    "名前": "BL 13.5-inch Mk V naval gun",
+    "ID": "SMHG025",
+    "重量": 80000,
+    "人員": 18,
+    "開発年": 1912,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 635.0,
+    "initial_velocity_mps": 830.0,
+    "rounds_per_minute": 2,
+    "caliber_cm": 34.3,
+    "barrel_length": 45,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMHG/SMHG026.json
+++ b/equipments/SMHG/SMHG026.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "大口径砲",
+  "common": {
+    "名前": "BL 13.5-inch Mk VI naval gun",
+    "ID": "SMHG026",
+    "重量": 82000,
+    "人員": 18,
+    "開発年": 1918,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 635.0,
+    "initial_velocity_mps": 750.0,
+    "rounds_per_minute": 2,
+    "caliber_cm": 34.3,
+    "barrel_length": 45,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMHG/SMHG027.json
+++ b/equipments/SMHG/SMHG027.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "大口径砲",
+  "common": {
+    "名前": "BL 14 inch gun Mk II",
+    "ID": "SMHG027",
+    "重量": 84000,
+    "人員": 18,
+    "開発年": 1913,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 721.0,
+    "initial_velocity_mps": 760.0,
+    "rounds_per_minute": 2,
+    "caliber_cm": 35.6,
+    "barrel_length": 45,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMHG/SMHG028.json
+++ b/equipments/SMHG/SMHG028.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "大口径砲",
+  "common": {
+    "名前": "BL 14-inch Mk VII naval gun",
+    "ID": "SMHG028",
+    "重量": 78000,
+    "人員": 18,
+    "開発年": 1938,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 721.0,
+    "initial_velocity_mps": 750.0,
+    "rounds_per_minute": 2,
+    "caliber_cm": 35.6,
+    "barrel_length": 45,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMHG/SMHG029.json
+++ b/equipments/SMHG/SMHG029.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "大口径砲",
+  "common": {
+    "名前": "BL 15-inch Mk I naval gun",
+    "ID": "SMHG029",
+    "重量": 100000,
+    "人員": 20,
+    "開発年": 1912,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 870.0,
+    "initial_velocity_mps": 750.0,
+    "rounds_per_minute": 2,
+    "caliber_cm": 38.1,
+    "barrel_length": 42,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMHG/SMHG030.json
+++ b/equipments/SMHG/SMHG030.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "大口径砲",
+  "common": {
+    "名前": "BL 16-inch Mk I naval gun",
+    "ID": "SMHG030",
+    "重量": 108000,
+    "人員": 20,
+    "開発年": 1927,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 929.0,
+    "initial_velocity_mps": 788.0,
+    "rounds_per_minute": 2,
+    "caliber_cm": 40.6,
+    "barrel_length": 45,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMHG/SMHG031.json
+++ b/equipments/SMHG/SMHG031.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "大口径砲",
+  "common": {
+    "名前": "BL 16.25-inch Mk I naval gun",
+    "ID": "SMHG031",
+    "重量": 111000,
+    "人員": 20,
+    "開発年": 1889,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 820.0,
+    "initial_velocity_mps": 650.0,
+    "rounds_per_minute": 1,
+    "caliber_cm": 41.3,
+    "barrel_length": 30,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMHG/SMHG032.json
+++ b/equipments/SMHG/SMHG032.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "大口径砲",
+  "common": {
+    "名前": "BL 18-inch Mk I naval gun",
+    "ID": "SMHG032",
+    "重量": 150000,
+    "人員": 22,
+    "開発年": 1917,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 1400.0,
+    "initial_velocity_mps": 730.0,
+    "rounds_per_minute": 1,
+    "caliber_cm": 45.7,
+    "barrel_length": 40,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMHG/SMHG033.json
+++ b/equipments/SMHG/SMHG033.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "大口径砲",
+  "common": {
+    "名前": "EOC 10-inch 45-calibre naval gun",
+    "ID": "SMHG033",
+    "重量": 32000,
+    "人員": 14,
+    "開発年": 1895,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 225.0,
+    "initial_velocity_mps": 815.0,
+    "rounds_per_minute": 2,
+    "caliber_cm": 25.4,
+    "barrel_length": 45,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMHG/SMHG034.json
+++ b/equipments/SMHG/SMHG034.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "大口径砲",
+  "common": {
+    "名前": "EOC 12-inch 45-calibre naval gun",
+    "ID": "SMHG034",
+    "重量": 57000,
+    "人員": 16,
+    "開発年": 1906,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 386.0,
+    "initial_velocity_mps": 820.0,
+    "rounds_per_minute": 2,
+    "caliber_cm": 30.5,
+    "barrel_length": 45,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMHG/SMHG035.json
+++ b/equipments/SMHG/SMHG035.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "大口径砲",
+  "common": {
+    "名前": "EOC 12-inch L/23.5",
+    "ID": "SMHG035",
+    "重量": 25000,
+    "人員": 16,
+    "開発年": 1880,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 375.0,
+    "initial_velocity_mps": 600.0,
+    "rounds_per_minute": 2,
+    "caliber_cm": 30.5,
+    "barrel_length": 24,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMHG/SMHG036.json
+++ b/equipments/SMHG/SMHG036.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "大口径砲",
+  "common": {
+    "名前": "EOC 12-inch L/27.5 43-ton gun",
+    "ID": "SMHG036",
+    "重量": 43000,
+    "人員": 16,
+    "開発年": 1885,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 355.0,
+    "initial_velocity_mps": 700.0,
+    "rounds_per_minute": 2,
+    "caliber_cm": 30.5,
+    "barrel_length": 28,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMHG/SMHG037.json
+++ b/equipments/SMHG/SMHG037.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "大口径砲",
+  "common": {
+    "名前": "EOC 14-inch 45-calibre naval gun",
+    "ID": "SMHG037",
+    "重量": 65000,
+    "人員": 18,
+    "開発年": 1912,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 650.0,
+    "initial_velocity_mps": 770.0,
+    "rounds_per_minute": 2,
+    "caliber_cm": 35.6,
+    "barrel_length": 45,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMLG/SMLG194.json
+++ b/equipments/SMLG/SMLG194.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "小口径砲",
+  "common": {
+    "名前": "1-inch Nordenfelt gun",
+    "ID": "SMLG194",
+    "重量": 0,
+    "人員": 0,
+    "開発年": 1880,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 0.0,
+    "initial_velocity_mps": 0.0,
+    "rounds_per_minute": 0,
+    "caliber_cm": 2.54,
+    "barrel_length": 0,
+    "barrel_count": 5,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMLG/SMLG195.json
+++ b/equipments/SMLG/SMLG195.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "小口径砲",
+  "common": {
+    "名前": "30mm DS30M Mark 2 Automated Small Calibre Gun",
+    "ID": "SMLG195",
+    "重量": 0,
+    "人員": 0,
+    "開発年": 2005,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 0.0,
+    "initial_velocity_mps": 0.0,
+    "rounds_per_minute": 0,
+    "caliber_cm": 3.0,
+    "barrel_length": 0,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMLG/SMLG196.json
+++ b/equipments/SMLG/SMLG196.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "小口径砲",
+  "common": {
+    "名前": "40CT cannon",
+    "ID": "SMLG196",
+    "重量": 0,
+    "人員": 0,
+    "開発年": 1993,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 0.0,
+    "initial_velocity_mps": 0.0,
+    "rounds_per_minute": 0,
+    "caliber_cm": 4.0,
+    "barrel_length": 0,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMLG/SMLG197.json
+++ b/equipments/SMLG/SMLG197.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "小口径砲",
+  "common": {
+    "名前": "4.5-inch Mark 8 naval gun",
+    "ID": "SMLG197",
+    "重量": 0,
+    "人員": 0,
+    "開発年": 1972,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 0.0,
+    "initial_velocity_mps": 0.0,
+    "rounds_per_minute": 0,
+    "caliber_cm": 11.4,
+    "barrel_length": 55,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMLG/SMLG198.json
+++ b/equipments/SMLG/SMLG198.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "小口径砲",
+  "common": {
+    "名前": "BL 4-inch Mk I–VI naval gun",
+    "ID": "SMLG198",
+    "重量": 2500,
+    "人員": 5,
+    "開発年": 1887,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 14.0,
+    "initial_velocity_mps": 700.0,
+    "rounds_per_minute": 6,
+    "caliber_cm": 10.2,
+    "barrel_length": 40,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMLG/SMLG199.json
+++ b/equipments/SMLG/SMLG199.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "小口径砲",
+  "common": {
+    "名前": "BL 4-inch Mk VII naval gun",
+    "ID": "SMLG199",
+    "重量": 2600,
+    "人員": 5,
+    "開発年": 1908,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 14.0,
+    "initial_velocity_mps": 710.0,
+    "rounds_per_minute": 6,
+    "caliber_cm": 10.2,
+    "barrel_length": 40,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMLG/SMLG200.json
+++ b/equipments/SMLG/SMLG200.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "小口径砲",
+  "common": {
+    "名前": "BL 4-inch Mk VIII naval gun",
+    "ID": "SMLG200",
+    "重量": 3000,
+    "人員": 5,
+    "開発年": 1915,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 14.0,
+    "initial_velocity_mps": 720.0,
+    "rounds_per_minute": 6,
+    "caliber_cm": 10.2,
+    "barrel_length": 40,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMLG/SMLG201.json
+++ b/equipments/SMLG/SMLG201.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "小口径砲",
+  "common": {
+    "名前": "BL 4-inch Mk IX naval gun",
+    "ID": "SMLG201",
+    "重量": 3300,
+    "人員": 5,
+    "開発年": 1916,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 14.0,
+    "initial_velocity_mps": 726.0,
+    "rounds_per_minute": 8,
+    "caliber_cm": 10.2,
+    "barrel_length": 45,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMLG/SMLG202.json
+++ b/equipments/SMLG/SMLG202.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "小口径砲",
+  "common": {
+    "名前": "BL 4.7-inch 45-calibre naval gun",
+    "ID": "SMLG202",
+    "重量": 3000,
+    "人員": 6,
+    "開発年": 1894,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 20.0,
+    "initial_velocity_mps": 690.0,
+    "rounds_per_minute": 5,
+    "caliber_cm": 12.0,
+    "barrel_length": 45,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMLG/SMLG203.json
+++ b/equipments/SMLG/SMLG203.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "小口径砲",
+  "common": {
+    "名前": "BL 5-inch gun Mk I – V",
+    "ID": "SMLG203",
+    "重量": 4000,
+    "人員": 6,
+    "開発年": 1895,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 25.0,
+    "initial_velocity_mps": 850.0,
+    "rounds_per_minute": 6,
+    "caliber_cm": 12.7,
+    "barrel_length": 50,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMLG/SMLG204.json
+++ b/equipments/SMLG/SMLG204.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "小口径砲",
+  "common": {
+    "名前": "Bofors 40 Mk4",
+    "ID": "SMLG204",
+    "重量": 2500,
+    "人員": 3,
+    "開発年": 2014,
+    "開発国": "Sweden",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 0.96,
+    "initial_velocity_mps": 1000.0,
+    "rounds_per_minute": 300,
+    "caliber_cm": 4.0,
+    "barrel_length": 70,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMLG/SMLG205.json
+++ b/equipments/SMLG/SMLG205.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "小口径砲",
+  "common": {
+    "名前": "Bofors 40 mm L/60 gun",
+    "ID": "SMLG205",
+    "重量": 2000,
+    "人員": 5,
+    "開発年": 1936,
+    "開発国": "Sweden",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 0.9,
+    "initial_velocity_mps": 850.0,
+    "rounds_per_minute": 120,
+    "caliber_cm": 4.0,
+    "barrel_length": 60,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMLG/SMLG206.json
+++ b/equipments/SMLG/SMLG206.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "小口径砲",
+  "common": {
+    "名前": "Bofors 40 mm Automatic Gun L/70",
+    "ID": "SMLG206",
+    "重量": 2500,
+    "人員": 5,
+    "開発年": 1950,
+    "開発国": "Sweden",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 0.96,
+    "initial_velocity_mps": 1020.0,
+    "rounds_per_minute": 240,
+    "caliber_cm": 4.0,
+    "barrel_length": 70,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMLG/SMLG207.json
+++ b/equipments/SMLG/SMLG207.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "小口径砲",
+  "common": {
+    "名前": "EOC 4-inch 50 caliber",
+    "ID": "SMLG207",
+    "重量": 3500,
+    "人員": 5,
+    "開発年": 1898,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 14.0,
+    "initial_velocity_mps": 850.0,
+    "rounds_per_minute": 8,
+    "caliber_cm": 10.2,
+    "barrel_length": 50,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMLG/SMLG208.json
+++ b/equipments/SMLG/SMLG208.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "小口径砲",
+  "common": {
+    "名前": "QF 2-pounder naval gun",
+    "ID": "SMLG208",
+    "重量": 1800,
+    "人員": 4,
+    "開発年": 1930,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 0.9,
+    "initial_velocity_mps": 700.0,
+    "rounds_per_minute": 100,
+    "caliber_cm": 4.0,
+    "barrel_length": 39,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMLG/SMLG209.json
+++ b/equipments/SMLG/SMLG209.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "小口径砲",
+  "common": {
+    "名前": "QF 3-pounder Hotchkiss",
+    "ID": "SMLG209",
+    "重量": 1100,
+    "人員": 3,
+    "開発年": 1886,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 1.5,
+    "initial_velocity_mps": 570.0,
+    "rounds_per_minute": 20,
+    "caliber_cm": 4.7,
+    "barrel_length": 40,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMLG/SMLG210.json
+++ b/equipments/SMLG/SMLG210.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "小口径砲",
+  "common": {
+    "名前": "QF 3-pounder Vickers",
+    "ID": "SMLG210",
+    "重量": 1500,
+    "人員": 3,
+    "開発年": 1905,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 1.5,
+    "initial_velocity_mps": 720.0,
+    "rounds_per_minute": 25,
+    "caliber_cm": 4.7,
+    "barrel_length": 50,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMLG/SMLG211.json
+++ b/equipments/SMLG/SMLG211.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "小口径砲",
+  "common": {
+    "名前": "QF 4-inch naval gun Mk I–III",
+    "ID": "SMLG211",
+    "重量": 2500,
+    "人員": 6,
+    "開発年": 1896,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 14.0,
+    "initial_velocity_mps": 720.0,
+    "rounds_per_minute": 8,
+    "caliber_cm": 10.2,
+    "barrel_length": 40,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMLG/SMLG212.json
+++ b/equipments/SMLG/SMLG212.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "小口径砲",
+  "common": {
+    "名前": "QF 4-inch naval gun Mk IV/XII/XXII",
+    "ID": "SMLG212",
+    "重量": 2600,
+    "人員": 6,
+    "開発年": 1911,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 14.0,
+    "initial_velocity_mps": 850.0,
+    "rounds_per_minute": 10,
+    "caliber_cm": 10.2,
+    "barrel_length": 45,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMLG/SMLG213.json
+++ b/equipments/SMLG/SMLG213.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "小口径砲",
+  "common": {
+    "名前": "QF 4-inch naval gun Mk V",
+    "ID": "SMLG213",
+    "重量": 2400,
+    "人員": 6,
+    "開発年": 1900,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 14.0,
+    "initial_velocity_mps": 720.0,
+    "rounds_per_minute": 8,
+    "caliber_cm": 10.2,
+    "barrel_length": 40,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMLG/SMLG214.json
+++ b/equipments/SMLG/SMLG214.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "小口径砲",
+  "common": {
+    "名前": "QF 4-inch naval gun Mk XVI",
+    "ID": "SMLG214",
+    "重量": 2000,
+    "人員": 7,
+    "開発年": 1933,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 15.9,
+    "initial_velocity_mps": 811.0,
+    "rounds_per_minute": 15,
+    "caliber_cm": 10.2,
+    "barrel_length": 45,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMLG/SMLG215.json
+++ b/equipments/SMLG/SMLG215.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "小口径砲",
+  "common": {
+    "名前": "QF 4-inch naval gun Mk XIX",
+    "ID": "SMLG215",
+    "重量": 2200,
+    "人員": 7,
+    "開発年": 1942,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 15.9,
+    "initial_velocity_mps": 792.0,
+    "rounds_per_minute": 15,
+    "caliber_cm": 10.2,
+    "barrel_length": 45,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMLG/SMLG216.json
+++ b/equipments/SMLG/SMLG216.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "小口径砲",
+  "common": {
+    "名前": "QF 4-inch naval gun Mk XXIII",
+    "ID": "SMLG216",
+    "重量": 2300,
+    "人員": 7,
+    "開発年": 1950,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 16.0,
+    "initial_velocity_mps": 820.0,
+    "rounds_per_minute": 20,
+    "caliber_cm": 10.2,
+    "barrel_length": 45,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMLG/SMLG217.json
+++ b/equipments/SMLG/SMLG217.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "小口径砲",
+  "common": {
+    "名前": "QF 4.7-inch Mk V naval gun",
+    "ID": "SMLG217",
+    "重量": 3200,
+    "人員": 7,
+    "開発年": 1914,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 23.0,
+    "initial_velocity_mps": 760.0,
+    "rounds_per_minute": 5,
+    "caliber_cm": 12.0,
+    "barrel_length": 45,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMLG/SMLG218.json
+++ b/equipments/SMLG/SMLG218.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "小口径砲",
+  "common": {
+    "名前": "QF 4.7-inch Mk VIII naval gun",
+    "ID": "SMLG218",
+    "重量": 3500,
+    "人員": 7,
+    "開発年": 1918,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 23.0,
+    "initial_velocity_mps": 814.0,
+    "rounds_per_minute": 8,
+    "caliber_cm": 12.0,
+    "barrel_length": 45,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMLG/SMLG219.json
+++ b/equipments/SMLG/SMLG219.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "小口径砲",
+  "common": {
+    "名前": "QF 4.7-inch Mk IX/XII naval gun",
+    "ID": "SMLG219",
+    "重量": 3700,
+    "人員": 7,
+    "開発年": 1930,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 23.4,
+    "initial_velocity_mps": 810.0,
+    "rounds_per_minute": 8,
+    "caliber_cm": 12.0,
+    "barrel_length": 45,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMLG/SMLG220.json
+++ b/equipments/SMLG/SMLG220.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "小口径砲",
+  "common": {
+    "名前": "QF 4.7-inch Mk XI naval gun",
+    "ID": "SMLG220",
+    "重量": 4000,
+    "人員": 7,
+    "開発年": 1938,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 23.5,
+    "initial_velocity_mps": 820.0,
+    "rounds_per_minute": 10,
+    "caliber_cm": 12.0,
+    "barrel_length": 45,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMLG/SMLG221.json
+++ b/equipments/SMLG/SMLG221.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "小口径砲",
+  "common": {
+    "名前": "QF 4.7-inch Mk I–IV naval gun",
+    "ID": "SMLG221",
+    "重量": 3000,
+    "人員": 6,
+    "開発年": 1892,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 20.0,
+    "initial_velocity_mps": 700.0,
+    "rounds_per_minute": 5,
+    "caliber_cm": 12.0,
+    "barrel_length": 40,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMLG/SMLG222.json
+++ b/equipments/SMLG/SMLG222.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "小口径砲",
+  "common": {
+    "名前": "QF 6-pounder Hotchkiss",
+    "ID": "SMLG222",
+    "重量": 1000,
+    "人員": 4,
+    "開発年": 1885,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 2.7,
+    "initial_velocity_mps": 590.0,
+    "rounds_per_minute": 25,
+    "caliber_cm": 5.7,
+    "barrel_length": 40,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMLG/SMLG223.json
+++ b/equipments/SMLG/SMLG223.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "小口径砲",
+  "common": {
+    "名前": "QF 6-pounder Nordenfelt",
+    "ID": "SMLG223",
+    "重量": 900,
+    "人員": 4,
+    "開発年": 1885,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 2.7,
+    "initial_velocity_mps": 563.0,
+    "rounds_per_minute": 20,
+    "caliber_cm": 5.7,
+    "barrel_length": 42,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMLG/SMLG224.json
+++ b/equipments/SMLG/SMLG224.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "小口径砲",
+  "common": {
+    "名前": "QF 6-pounder 10 cwt gun",
+    "ID": "SMLG224",
+    "重量": 1250,
+    "人員": 4,
+    "開発年": 1917,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 2.7,
+    "initial_velocity_mps": 727.0,
+    "rounds_per_minute": 20,
+    "caliber_cm": 5.7,
+    "barrel_length": 50,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMLG/SMLG225.json
+++ b/equipments/SMLG/SMLG225.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "小口径砲",
+  "common": {
+    "名前": "QF 12-pounder 8 cwt gun",
+    "ID": "SMLG225",
+    "重量": 814,
+    "人員": 4,
+    "開発年": 1894,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 5.7,
+    "initial_velocity_mps": 719.0,
+    "rounds_per_minute": 15,
+    "caliber_cm": 7.6,
+    "barrel_length": 40,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMLG/SMLG226.json
+++ b/equipments/SMLG/SMLG226.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "小口径砲",
+  "common": {
+    "名前": "QF 12-pounder 12 cwt naval gun",
+    "ID": "SMLG226",
+    "重量": 1067,
+    "人員": 5,
+    "開発年": 1894,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 5.7,
+    "initial_velocity_mps": 719.0,
+    "rounds_per_minute": 15,
+    "caliber_cm": 7.6,
+    "barrel_length": 40,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMLG/SMLG227.json
+++ b/equipments/SMLG/SMLG227.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "小口径砲",
+  "common": {
+    "名前": "QF 12-pounder 18 cwt naval gun",
+    "ID": "SMLG227",
+    "重量": 1372,
+    "人員": 5,
+    "開発年": 1897,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 5.7,
+    "initial_velocity_mps": 719.0,
+    "rounds_per_minute": 20,
+    "caliber_cm": 7.6,
+    "barrel_length": 45,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMLG/SMLG228.json
+++ b/equipments/SMLG/SMLG228.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "小口径砲",
+  "common": {
+    "名前": "QF 13-pounder gun",
+    "ID": "SMLG228",
+    "重量": 850,
+    "人員": 5,
+    "開発年": 1904,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 6.2,
+    "initial_velocity_mps": 740.0,
+    "rounds_per_minute": 20,
+    "caliber_cm": 7.6,
+    "barrel_length": 45,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMLG/SMLG229.json
+++ b/equipments/SMLG/SMLG229.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "小口径砲",
+  "common": {
+    "名前": "QF 14-pounder Maxim-Nordenfelt naval gun",
+    "ID": "SMLG229",
+    "重量": 1000,
+    "人員": 5,
+    "開発年": 1890,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 6.3,
+    "initial_velocity_mps": 720.0,
+    "rounds_per_minute": 15,
+    "caliber_cm": 8.9,
+    "barrel_length": 40,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMLG/SMLG230.json
+++ b/equipments/SMLG/SMLG230.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "小口径砲",
+  "common": {
+    "名前": "QF 14-pounder naval gun Mk I & II",
+    "ID": "SMLG230",
+    "重量": 1100,
+    "人員": 5,
+    "開発年": 1895,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 6.3,
+    "initial_velocity_mps": 770.0,
+    "rounds_per_minute": 15,
+    "caliber_cm": 8.9,
+    "barrel_length": 45,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMMG/SMMG041.json
+++ b/equipments/SMMG/SMMG041.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "中口径砲",
+  "common": {
+    "名前": "5.25\"/50 (13.4 cm) QF Mark I (Twin Mount)",
+    "ID": "SMMG041",
+    "重量": 81000,
+    "人員": 20,
+    "開発年": 1938,
+    "開発国": "GBR",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 36.3,
+    "initial_velocity_mps": 792,
+    "rounds_per_minute": 7,
+    "caliber_cm": 13.4,
+    "barrel_length": 50,
+    "barrel_count": 2,
+    "max_elevation": "+70/-5 度",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMMG/SMMG042.json
+++ b/equipments/SMMG/SMMG042.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "中口径砲",
+  "common": {
+    "名前": "15 cm/45 41st Year Type",
+    "ID": "SMMG042",
+    "重量": 0,
+    "人員": 0,
+    "開発年": 1908,
+    "開発国": "Japan",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 0.0,
+    "initial_velocity_mps": 0.0,
+    "rounds_per_minute": 0,
+    "caliber_cm": 15.0,
+    "barrel_length": 45,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMMG/SMMG043.json
+++ b/equipments/SMMG/SMMG043.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "中口径砲",
+  "common": {
+    "名前": "32-pounder 56 cwt",
+    "ID": "SMMG043",
+    "重量": 0,
+    "人員": 0,
+    "開発年": 1847,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 0.0,
+    "initial_velocity_mps": 0.0,
+    "rounds_per_minute": 0,
+    "caliber_cm": 16.0,
+    "barrel_length": 0,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMMG/SMMG044.json
+++ b/equipments/SMMG/SMMG044.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "中口径砲",
+  "common": {
+    "名前": "32-pounder gun",
+    "ID": "SMMG044",
+    "重量": 0,
+    "人員": 0,
+    "開発年": 1830,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 0.0,
+    "initial_velocity_mps": 0.0,
+    "rounds_per_minute": 0,
+    "caliber_cm": 16.0,
+    "barrel_length": 0,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMMG/SMMG045.json
+++ b/equipments/SMMG/SMMG045.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "中口径砲",
+  "common": {
+    "名前": "70-pounder Whitworth naval gun",
+    "ID": "SMMG045",
+    "重量": 0,
+    "人員": 0,
+    "開発年": 1865,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 0.0,
+    "initial_velocity_mps": 0.0,
+    "rounds_per_minute": 0,
+    "caliber_cm": 14.0,
+    "barrel_length": 0,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMMG/SMMG046.json
+++ b/equipments/SMMG/SMMG046.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "中口径砲",
+  "common": {
+    "名前": "120-pounder Whitworth naval gun",
+    "ID": "SMMG046",
+    "重量": 0,
+    "人員": 0,
+    "開発年": 1870,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 0.0,
+    "initial_velocity_mps": 0.0,
+    "rounds_per_minute": 0,
+    "caliber_cm": 18.0,
+    "barrel_length": 0,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMMG/SMMG047.json
+++ b/equipments/SMMG/SMMG047.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "中口径砲",
+  "common": {
+    "名前": "BL 5.5-inch Mk I naval gun",
+    "ID": "SMMG047",
+    "重量": 7500,
+    "人員": 7,
+    "開発年": 1918,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 36.0,
+    "initial_velocity_mps": 800.0,
+    "rounds_per_minute": 5,
+    "caliber_cm": 14.0,
+    "barrel_length": 50,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMMG/SMMG048.json
+++ b/equipments/SMMG/SMMG048.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "中口径砲",
+  "common": {
+    "名前": "BL 6-inch 80-pounder gun",
+    "ID": "SMMG048",
+    "重量": 5000,
+    "人員": 7,
+    "開発年": 1880,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 36.0,
+    "initial_velocity_mps": 575.0,
+    "rounds_per_minute": 4,
+    "caliber_cm": 15.2,
+    "barrel_length": 30,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMMG/SMMG049.json
+++ b/equipments/SMMG/SMMG049.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "中口径砲",
+  "common": {
+    "名前": "BL 6-inch Mk II–VI naval gun",
+    "ID": "SMMG049",
+    "重量": 7000,
+    "人員": 7,
+    "開発年": 1883,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 45.0,
+    "initial_velocity_mps": 700.0,
+    "rounds_per_minute": 5,
+    "caliber_cm": 15.2,
+    "barrel_length": 40,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMMG/SMMG050.json
+++ b/equipments/SMMG/SMMG050.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "中口径砲",
+  "common": {
+    "名前": "BL 6-inch Mk VII naval gun",
+    "ID": "SMMG050",
+    "重量": 7520,
+    "人員": 6,
+    "開発年": 1899,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 45.4,
+    "initial_velocity_mps": 773.0,
+    "rounds_per_minute": 5,
+    "caliber_cm": 15.2,
+    "barrel_length": 45,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMMG/SMMG051.json
+++ b/equipments/SMMG/SMMG051.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "中口径砲",
+  "common": {
+    "名前": "BL 6-inch Mk XI naval gun",
+    "ID": "SMMG051",
+    "重量": 9000,
+    "人員": 7,
+    "開発年": 1904,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 45.0,
+    "initial_velocity_mps": 850.0,
+    "rounds_per_minute": 5,
+    "caliber_cm": 15.2,
+    "barrel_length": 50,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMMG/SMMG052.json
+++ b/equipments/SMMG/SMMG052.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "中口径砲",
+  "common": {
+    "名前": "BL 6-inch Mk XII naval gun",
+    "ID": "SMMG052",
+    "重量": 9100,
+    "人員": 7,
+    "開発年": 1906,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 45.0,
+    "initial_velocity_mps": 760.0,
+    "rounds_per_minute": 5,
+    "caliber_cm": 15.2,
+    "barrel_length": 45,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMMG/SMMG053.json
+++ b/equipments/SMMG/SMMG053.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "中口径砲",
+  "common": {
+    "名前": "BL 6-inch Mk XIII – XVIII naval gun",
+    "ID": "SMMG053",
+    "重量": 9200,
+    "人員": 7,
+    "開発年": 1914,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 45.0,
+    "initial_velocity_mps": 760.0,
+    "rounds_per_minute": 5,
+    "caliber_cm": 15.2,
+    "barrel_length": 45,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMMG/SMMG054.json
+++ b/equipments/SMMG/SMMG054.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "中口径砲",
+  "common": {
+    "名前": "BL 6-inch Mk XXII naval gun",
+    "ID": "SMMG054",
+    "重量": 9500,
+    "人員": 7,
+    "開発年": 1942,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 50.0,
+    "initial_velocity_mps": 840.0,
+    "rounds_per_minute": 8,
+    "caliber_cm": 15.2,
+    "barrel_length": 50,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMMG/SMMG055.json
+++ b/equipments/SMMG/SMMG055.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "中口径砲",
+  "common": {
+    "名前": "BL 6-inch Mk XXIII naval gun",
+    "ID": "SMMG055",
+    "重量": 9600,
+    "人員": 7,
+    "開発年": 1944,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 50.0,
+    "initial_velocity_mps": 845.0,
+    "rounds_per_minute": 8,
+    "caliber_cm": 15.2,
+    "barrel_length": 50,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMMG/SMMG056.json
+++ b/equipments/SMMG/SMMG056.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "中口径砲",
+  "common": {
+    "名前": "BL 7.5-inch Mk I naval gun",
+    "ID": "SMMG056",
+    "重量": 12000,
+    "人員": 8,
+    "開発年": 1901,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 91.0,
+    "initial_velocity_mps": 770.0,
+    "rounds_per_minute": 4,
+    "caliber_cm": 19.0,
+    "barrel_length": 45,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMMG/SMMG057.json
+++ b/equipments/SMMG/SMMG057.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "中口径砲",
+  "common": {
+    "名前": "BL 7.5-inch Mk II – V naval gun",
+    "ID": "SMMG057",
+    "重量": 13000,
+    "人員": 8,
+    "開発年": 1905,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 91.0,
+    "initial_velocity_mps": 780.0,
+    "rounds_per_minute": 4,
+    "caliber_cm": 19.0,
+    "barrel_length": 45,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMMG/SMMG058.json
+++ b/equipments/SMMG/SMMG058.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "中口径砲",
+  "common": {
+    "名前": "BL 7.5-inch Mk VI naval gun",
+    "ID": "SMMG058",
+    "重量": 14000,
+    "人員": 8,
+    "開発年": 1920,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 91.0,
+    "initial_velocity_mps": 808.0,
+    "rounds_per_minute": 5,
+    "caliber_cm": 19.0,
+    "barrel_length": 50,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMMG/SMMG059.json
+++ b/equipments/SMMG/SMMG059.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "中口径砲",
+  "common": {
+    "名前": "BL 8-inch Mk I – VII naval gun",
+    "ID": "SMMG059",
+    "重量": 15500,
+    "人員": 8,
+    "開発年": 1895,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 116.0,
+    "initial_velocity_mps": 855.0,
+    "rounds_per_minute": 3,
+    "caliber_cm": 20.3,
+    "barrel_length": 45,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMMG/SMMG060.json
+++ b/equipments/SMMG/SMMG060.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "中口径砲",
+  "common": {
+    "名前": "BL 8-inch Mk VIII naval gun",
+    "ID": "SMMG060",
+    "重量": 16000,
+    "人員": 8,
+    "開発年": 1924,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 116.0,
+    "initial_velocity_mps": 855.0,
+    "rounds_per_minute": 5,
+    "caliber_cm": 20.3,
+    "barrel_length": 50,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMMG/SMMG061.json
+++ b/equipments/SMMG/SMMG061.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "中口径砲",
+  "common": {
+    "名前": "QF 5.25-inch naval gun",
+    "ID": "SMMG061",
+    "重量": 40000,
+    "人員": 12,
+    "開発年": 1938,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 36.3,
+    "initial_velocity_mps": 792.0,
+    "rounds_per_minute": 7,
+    "caliber_cm": 13.4,
+    "barrel_length": 50,
+    "barrel_count": 1,
+    "max_elevation": "+70/-5 度",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMMG/SMMG062.json
+++ b/equipments/SMMG/SMMG062.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "中口径砲",
+  "common": {
+    "名前": "QF 6-inch Mk I–III naval gun",
+    "ID": "SMMG062",
+    "重量": 7500,
+    "人員": 9,
+    "開発年": 1895,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 45.0,
+    "initial_velocity_mps": 700.0,
+    "rounds_per_minute": 5,
+    "caliber_cm": 15.2,
+    "barrel_length": 40,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMMG/SMMG063.json
+++ b/equipments/SMMG/SMMG063.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "中口径砲",
+  "common": {
+    "名前": "QF 6-inch naval gun",
+    "ID": "SMMG063",
+    "重量": 7800,
+    "人員": 9,
+    "開発年": 1905,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 45.0,
+    "initial_velocity_mps": 830.0,
+    "rounds_per_minute": 6,
+    "caliber_cm": 15.2,
+    "barrel_length": 45,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}

--- a/equipments/SMMG/SMMG064.json
+++ b/equipments/SMMG/SMMG064.json
@@ -1,0 +1,26 @@
+{
+  "equipment_type": "中口径砲",
+  "common": {
+    "名前": "QF 6-inch Mark N5 gun",
+    "ID": "SMMG064",
+    "重量": 8000,
+    "人員": 9,
+    "開発年": 1945,
+    "開発国": "United Kingdom",
+    "必要資源_鉄": 0,
+    "必要資源_クロム": 0,
+    "必要資源_アルミ": 0,
+    "必要資源_タングステン": 0,
+    "必要資源_ゴム": 0
+  },
+  "specific": {
+    "shell_weight_kg": 45.0,
+    "initial_velocity_mps": 864.0,
+    "rounds_per_minute": 10,
+    "caliber_cm": 15.2,
+    "barrel_length": 50,
+    "barrel_count": 1,
+    "max_elevation": "",
+    "turret_count": 1
+  }
+}


### PR DESCRIPTION
## Summary
- add QF 2-, 3-, 4-, and 6-pounder guns
- include QF 4-inch and 4.7-inch gun series
- define QF 5.25-inch and several 6-inch naval guns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877a75cd2cc8322921fcdb0acf84e78